### PR TITLE
fix: 对齐 Ollama 模型元数据输出

### DIFF
--- a/OllamaHub/Contracts/OllamaContracts.cs
+++ b/OllamaHub/Contracts/OllamaContracts.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace OllamaHub.Contracts;
@@ -25,6 +25,30 @@ public sealed class OllamaModelDescriptor
 
     [JsonPropertyName("digest")]
     public required string Digest { get; init; }
+
+    [JsonPropertyName("capabilities")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? Capabilities { get; init; }
+
+    [JsonPropertyName("context_length")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ContextLength { get; init; }
+
+    [JsonPropertyName("max_context_length")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxContextLength { get; init; }
+
+    [JsonPropertyName("max_input_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxInputTokens { get; init; }
+
+    [JsonPropertyName("max_output_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxOutputTokens { get; init; }
+
+    [JsonPropertyName("model_info")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, object>? ModelInfo { get; init; }
 
     [JsonPropertyName("details")]
     public required OllamaModelDetails Details { get; init; }
@@ -76,6 +100,22 @@ public sealed class OllamaShowResponse
 
     [JsonPropertyName("capabilities")]
     public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    [JsonPropertyName("context_length")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ContextLength { get; init; }
+
+    [JsonPropertyName("max_context_length")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxContextLength { get; init; }
+
+    [JsonPropertyName("max_input_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxInputTokens { get; init; }
+
+    [JsonPropertyName("max_output_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxOutputTokens { get; init; }
 
     [JsonPropertyName("model_info")]
     public required IReadOnlyDictionary<string, object> ModelInfo { get; init; }

--- a/OllamaHub/Program.cs
+++ b/OllamaHub/Program.cs
@@ -97,25 +97,19 @@ app.MapPost("/api/show", (IOllamaHubConfigProvider configProvider, OllamaShowReq
         });
     }
 
-    var capabilities = model.Vision
-        ? new[] { "completion", "tools", "vision" }
-        : new[] { "completion", "tools" };
+    var capabilities = BuildCapabilities(model);
 
     return Results.Ok(new OllamaShowResponse
     {
-        Modelfile = $"FROM {model.AnthropicModel}",
-        Parameters = $"family={model.Family}\ncontext_length={model.ContextLength}\nmax_tokens={model.MaxTokens}",
+        Modelfile = $"# OllamaHub proxy\nFROM {model.AnthropicModel}\nPARAMETER num_ctx {model.ContextLength}",
+        Parameters = $"num_ctx {model.ContextLength}\nfamily={model.Family}\ncontext_length={model.ContextLength}\nmax_tokens={model.MaxTokens}",
         Details = ToDescriptor(model).Details,
         Capabilities = capabilities,
-        ModelInfo = new Dictionary<string, object>
-        {
-            ["provider"] = model.ProviderId,
-            ["anthropic_model"] = model.AnthropicModel,
-            ["context_length"] = model.ContextLength,
-            ["max_tokens"] = model.MaxTokens,
-            ["capabilities"] = capabilities,
-            ["vision"] = model.Vision,
-        }
+        ContextLength = model.ContextLength,
+        MaxContextLength = model.ContextLength,
+        MaxInputTokens = model.ContextLength,
+        MaxOutputTokens = model.MaxTokens,
+        ModelInfo = BuildModelInfo(model)
     });
 });
 
@@ -161,14 +155,44 @@ static OllamaModelDescriptor ToDescriptor(ResolvedModelConfig model) =>
         ModifiedAt = DateTimeOffset.UtcNow.ToString("O"),
         Size = 0,
         Digest = OllamaHubConfigLoader.BuildDigest(model),
+        Capabilities = BuildCapabilities(model),
+        ContextLength = model.ContextLength,
+        MaxContextLength = model.ContextLength,
+        MaxInputTokens = model.ContextLength,
+        MaxOutputTokens = model.MaxTokens,
+        ModelInfo = BuildModelInfo(model),
         Details = new OllamaModelDetails
         {
-            Family = "",
-            Families = [""],
+            Family = model.Family,
+            Families = [model.Family],
             ParameterSize = "",
             QuantizationLevel = "proxy"
         }
     };
+
+static string[] BuildCapabilities(ResolvedModelConfig model) =>
+    model.Vision
+        ? ["completion", "tools", "vision"]
+        : ["completion", "tools"];
+
+static IReadOnlyDictionary<string, object> BuildModelInfo(ResolvedModelConfig model)
+{
+    var outputTokens = Math.Min(model.MaxTokens, Math.Max(model.ContextLength - 1, 0));
+    return new Dictionary<string, object>
+    {
+        ["provider"] = model.ProviderId,
+        ["anthropic_model"] = model.AnthropicModel,
+        ["general.architecture"] = model.Family,
+        ["general.context_length"] = model.ContextLength,
+        [model.Family + ".context_length"] = model.ContextLength,
+        ["context_length"] = model.ContextLength,
+        ["max_tokens"] = model.MaxTokens,
+        ["capabilities"] = BuildCapabilities(model),
+        ["vision"] = model.Vision,
+        ["num_ctx"] = model.ContextLength,
+        ["max_output_tokens"] = outputTokens
+    };
+}
 
 static IResult ToError(HttpStatusCode statusCode, string? error)
 {


### PR DESCRIPTION
## 问题

在 Visual Studio Copilot Chat BYOM（Ollama 入口）中使用 OllamaHub 时，所有模型的上下文长度都显示为相同的 100K，`settings.json` 中配置的 `context_length`、`max_tokens`、`family` 等元数据完全没有透传到客户端。

```json
// curl 127.0.0.1:11434/api/tags
{"models":[{"name":"MyAPI/deepseek-v4-flash","model":"deepseek-v4-flash","modified_at":"2026-08-23T13:13:41.4536740+00:00","size":0,"digest":"xxx","details":{"parent_model":"","format":"hub","family":"","families":[""],"parameter_size":"","quantization_level":"proxy"}}]}
```

## 根因

Visual Studio 读取 Ollama 模型上下文长度的各条路径（`/api/show` 的 `parameters` 中 `num_ctx`、顶层 `context_length` / `max_context_length`、`model_info` 中的上下文键等）此前均未被 OllamaHub 满足：

- `parameters` 输出的是 `context_length=1000000`（键名与格式均不匹配）
- `/api/tags` 条目和 `/api/show` 顶层均无 `context_length` / `max_context_length` / `max_input_tokens` / `max_output_tokens` 字段
- `details.family` / `families` 被硬编码为空字符串

客户端所有路径读取失败后回退到内置默认值，导致所有模型统一显示 100K。

## 修改

Visual Studio 不开源，找了个项目（ https://github.com/ollama/ollama-vscode/blob/main/src/provider.ts ），让AI辅助完成对齐工作：

- `OllamaContracts.cs`：`OllamaModelDescriptor` 与 `OllamaShowResponse` 新增 `capabilities`、`context_length`、`max_context_length`、`max_input_tokens`、`max_output_tokens`、`model_info` 字段
- `Program.cs`：
  - 新增 `BuildCapabilities` / `BuildModelInfo` 统一构建函数，`/api/tags` 与 `/api/show` 共用
  - `parameters` 首行输出 `num_ctx <n>`，`modelfile` 增加 `PARAMETER num_ctx`
  - `details.family` / `families` 输出配置的真实 `family`
  - `model_info` 补充 `general.architecture`、`general.context_length`、`<family>.context_length` 等 Ollama 风格键

## 验证

- [x] `dotnet test` 全部 34 个测试通过
- [x] 实测 `/api/tags` 每个模型条目返回配置的真实值

   ```json
   {"models":[{"name":"MyAPI/deepseek-v4-flash","model":"deepseek-v4-flash","modified_at":"2026-08-23T13:40:26.1797908+00:00","size":0,"digest":"xxx","capabilities":["completion","tools"],"context_length":200000,"max_context_length":200000,"max_input_tokens":200000,"max_output_tokens":128000,"model_info":{"provider":"MyAPI","anthropic_model":"deepseek-v4-flash","general.architecture":"deepseek","general.context_length":200000,"deepseek.context_length":200000,"context_length":200000,"max_tokens":128000,"capabilities":["completion","tools"],"vision":false,"num_ctx":200000,"max_output_tokens":128000},"details":{"parent_model":"","format":"hub","family":"deepseek","families":["deepseek"],"parameter_size":"","quantization_level":"proxy"}}]}
   ```

- [x] **已在 Visual Studio 中实测：各模型显示 settings.json 配置的真实上下文长度，不再统一为 100K**

   <img width="1157" height="360" alt="image" src="https://github.com/user-attachments/assets/46a171f3-7253-4301-a4cf-fd0b78e97cdd" />


## 兼容性

新增字段均为可选输出，不影响现有 Ollama 客户端；`/api/show` 原有字段保持不变。